### PR TITLE
Added react-hook-form to the BazaWiedzy

### DIFF
--- a/BazaWiedzy/package.json
+++ b/BazaWiedzy/package.json
@@ -21,6 +21,7 @@
     "postcss": "8.4.24",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-hook-form": "^7.44.3",
     "tailwindcss": "3.3.2",
     "typescript": "5.0.4"
   },

--- a/BazaWiedzy/package.json
+++ b/BazaWiedzy/package.json
@@ -21,7 +21,7 @@
     "postcss": "8.4.24",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-hook-form": "^7.44.3",
+    "react-hook-form": "7.44.3",
     "tailwindcss": "3.3.2",
     "typescript": "5.0.4"
   },

--- a/BazaWiedzy/yarn.lock
+++ b/BazaWiedzy/yarn.lock
@@ -3963,7 +3963,7 @@ react-dom@18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
-react-hook-form@^7.44.3:
+react-hook-form@7.44.3:
   version "7.44.3"
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.44.3.tgz#a99e560c6ef2b668db1daaebc4f98267331b6828"
   integrity sha512-/tHId6p2ViAka1wECMw8FEPn/oz/w226zehHrJyQ1oIzCBNMIJCaj6ZkQcv+MjDxYh9MWR7RQic7Qqwe4a5nkw==

--- a/BazaWiedzy/yarn.lock
+++ b/BazaWiedzy/yarn.lock
@@ -3963,6 +3963,11 @@ react-dom@18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
+react-hook-form@^7.44.3:
+  version "7.44.3"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.44.3.tgz#a99e560c6ef2b668db1daaebc4f98267331b6828"
+  integrity sha512-/tHId6p2ViAka1wECMw8FEPn/oz/w226zehHrJyQ1oIzCBNMIJCaj6ZkQcv+MjDxYh9MWR7RQic7Qqwe4a5nkw==
+
 react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
### **_Form Framework Council (FFC)_ decided on using _react-hook-form_.**

There were two competitors consisting of _**Formik**_ and _**react-hook-form**_.

Janitor decided to formalize a quick summary explaining our choice.
- Some members of the council tried both frameworks and found _**react-hook-form**_ to be easier to use. This may be because of simplicity of said framework, as it is much more ligthweight than _**Formik**_.
- The _**react-hook-form**_ displays better performance regarding load times and amount of re-renders.
- It also has slightly more stars on github with comparable amount of projects using it, it is not a significant argument.